### PR TITLE
fixed test.sh for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@
 
 <h3>Execute JUnit tests</h3>
 1. Run containers in detached mode:<br><code>docker-compose up -d</code><br>NOTE: If containers are already running stop them with CTRL+C<br><br>
-2. Run this script with docker:<br><code>docker exec -it shortify_server_1 /usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar target/shortify-server-test-jar-with-dependencies.jar</code><br><br>
-3. Results of the tests will be shown in the terminal.<br>
+2. Convert test.sh with <a href="http://www.linuxcommand.org/man_pages/dos2unix1.html">dos2unix</a>:<code> docker exec -it shortify_server_1 dos2unix test.sh</code><br><br>
+3. Run this script with docker:<br><code> docker exec -it shortify_server_1 bash test.sh</code><br><br>
+4. Results of the tests will be shown in the terminal.<br>
 
 
 

--- a/Shortify-server/Dockerfile
+++ b/Shortify-server/Dockerfile
@@ -7,6 +7,9 @@ EXPOSE 4567
 RUN apt-get update
 RUN apt-get install -y maven
 
+#install dos2unix to run test.sh from windows
+RUN apt-get install -y dos2unix
+
 WORKDIR /code
 
 COPY . /code


### PR DESCRIPTION
Fixed the use of test.sh while using a linux VM on windows by converting test.sh in unix format using dos2unix.
